### PR TITLE
Specified the platform for docker build process

### DIFF
--- a/scripts/build_image.sh
+++ b/scripts/build_image.sh
@@ -5,4 +5,4 @@
 
 set -eux
 
-docker build . -t integrals:latest
+docker buildx build --platform linux/amd64 . -t integrals:latest


### PR DESCRIPTION
This update allows users with non-x86/64 platforms to build the docker image.